### PR TITLE
Woos

### DIFF
--- a/modelproject/Dockerfile
+++ b/modelproject/Dockerfile
@@ -31,3 +31,7 @@ RUN uv sync --no-dev --extra prod --frozen
 
 # 앱 소스 복사
 COPY . .
+
+WORKDIR /app/modelproject
+
+CMD ["gunicorn", "--bind", "0.0.0.0:8000", "modelproject.wsgi:application"]

--- a/modelproject/accounts/apps.py
+++ b/modelproject/accounts/apps.py
@@ -15,4 +15,4 @@ class AccountsConfig(AppConfig):
 
     def ready(self):
         # 시그널 핸들러를 등록
-        import accounts.signals
+        from . import signals

--- a/modelproject/accounts/apps.py
+++ b/modelproject/accounts/apps.py
@@ -14,5 +14,5 @@ class AccountsConfig(AppConfig):
     name = 'accounts'
 
     def ready(self):
-        # 시그널 핸들러를 등록
+        # 시그널 핸들러를 등록 
         from . import signals

--- a/modelproject/accounts/models.py
+++ b/modelproject/accounts/models.py
@@ -6,7 +6,7 @@ from typing import Literal
 from django.contrib.auth.models import AbstractUser
 from django.db import models
 
-
+# ------------------------ User -------------------------
 class User(AbstractUser):
     """
     커스텀 사용자 모델.
@@ -42,7 +42,7 @@ class User(AbstractUser):
         """손님 여부 헬퍼."""
         return self.role == self.Role.CUSTOMER
 
-
+# ------------------------ 자주 가는 지역 -------------------------
 class FavoriteLocation(models.Model):
     """
     사용자가 자주 가는 지역을 저장하는 모델.

--- a/modelproject/accounts/models.py
+++ b/modelproject/accounts/models.py
@@ -16,7 +16,7 @@ class User(AbstractUser):
     class Role(models.TextChoices):
         """
         사용자의 역할을 정의하는 클래스입니다.
-        'CUSTOMER'와 'OWNER' 두 가지 역할을 제공합니다.
+        'CUSTOMER: 손님'와 'OWNER: 점주' 두 가지 역할을 제공합니다.
         'models.CharField'의 'choices' 옵션과 함께 사용되어,
         데이터베이스에 저장될 값과 사용자에게 보여줄 값을 구분합니다.
         """
@@ -28,7 +28,7 @@ class User(AbstractUser):
         max_length=20,
         choices=Role.choices,
         default=Role.CUSTOMER,
-        help_text="사용자 역할",
+        help_text="사용자 역할(CUSTOMER/OWNER)",
     )
     phone: str | None = models.CharField(
         max_length=20, null=True, blank=True, help_text="연락처(선택)"
@@ -45,7 +45,7 @@ class User(AbstractUser):
 
 class FavoriteLocation(models.Model):
     """
-    사용자가 즐겨찾는 지역을 저장하는 모델.
+    사용자가 자주 가는 지역을 저장하는 모델.
     한 명의 사용자는 여러 개의 FavoriteLocation을 가질 수 있습니다.
     """
 

--- a/modelproject/accounts/serializers.py
+++ b/modelproject/accounts/serializers.py
@@ -16,7 +16,7 @@ from .models import FavoriteLocation, User
 
 User: type[AbstractUser] = get_user_model()
 
-
+# ------------------------ 자주 가는 지역 -------------------------
 class FavoriteLocationSerializer(serializers.ModelSerializer):
     """
     자주 가는 지역(`FavoriteLocation`) 모델을 위한, 정보를 직렬화하는 시리얼라이저입니다.
@@ -32,7 +32,7 @@ class FavoriteLocationSerializer(serializers.ModelSerializer):
         #     "district": "장안구"
         # }
 
-
+# ------------------------ 회원가입 기반 로직 -------------------------
 class BaseRegisterSerializer(serializers.ModelSerializer):
     """
     사용자 회원 가입의 기본 필드를 정의하는 시리얼라이저입니다.
@@ -93,7 +93,7 @@ class BaseRegisterSerializer(serializers.ModelSerializer):
 
         return user
 
-
+# ------------------------ 손님 회원가입 -------------------------
 class RegisterCustomerSerializer(BaseRegisterSerializer):
     """
     '손님' 회원의 가입을 처리하는 시리얼라이저입니다.
@@ -108,7 +108,7 @@ class RegisterCustomerSerializer(BaseRegisterSerializer):
     class Meta(BaseRegisterSerializer.Meta):
         fields: tuple[Literal['id'], Literal['username'], Literal['email'], Literal['password'], Literal['phone']] = BaseRegisterSerializer.Meta.fields + ("favorite_locations",)
 
-
+# ------------------------ 점주 회원가입 -------------------------
 class RegisterOwnerSerializer(BaseRegisterSerializer):
     """
     '점주' 회원의 가입을 처리하는 시리얼라이저입니다.
@@ -122,7 +122,7 @@ class RegisterOwnerSerializer(BaseRegisterSerializer):
         fields: tuple[Literal['id'], Literal['username'], Literal['email'], Literal['password'], Literal['phone']] = BaseRegisterSerializer.Meta.fields + ("place",)
 
 
-
+# ------------------------ 사용자 프로필 업데이트 -------------------------
 class UserUpdateSerializer(serializers.ModelSerializer):
     """
     사용자 프로필 업데이트를 위한 시리얼라이저입니다.
@@ -169,7 +169,7 @@ class UserUpdateSerializer(serializers.ModelSerializer):
 
         return instance
 
-
+# ------------------------ 사용자 기본 정보 반환 -------------------------
 class UserMiniSerializer(serializers.ModelSerializer):
     """
     JWT 토큰 응답에 포함될 최소한의 사용자 정보를 직렬화하는 시리얼라이저입니다.
@@ -186,7 +186,7 @@ class UserMiniSerializer(serializers.ModelSerializer):
             "role",
         )
 
-
+# ------------------------ 사용자 프로필 조회 -------------------------
 class MeSerializer(serializers.ModelSerializer):
     """
     로그인한 사용자의 상세 프로필 정보를 조회하기 위한 시리얼라이저입니다.

--- a/modelproject/accounts/serializers.py
+++ b/modelproject/accounts/serializers.py
@@ -8,26 +8,36 @@ from django.contrib.auth.password_validation import validate_password
 from django.core.exceptions import ValidationError as DjangoValidationError
 from django.db import transaction
 from rest_framework import serializers
-
-from .models import FavoriteLocation, User
-# ----------여기 추가-----------
+# 점주 가입 시 가게 정보(Place 모델)를 중첩으로 생성/조회하기 위해 참조
 from couponbook.serializers import PlaceCreateSerializer, PlaceSerializer
 from couponbook.models import Place
+from .models import FavoriteLocation, User
+
 
 User: type[AbstractUser] = get_user_model()
 
 
 class FavoriteLocationSerializer(serializers.ModelSerializer):
     """
-    자주 가는 지역(`FavoriteLocation`) 모델을 위한 시리얼라이저입니다.
-    사용자의 자주 가는 지역 정보를 직렬화하고 유효성을 검사합니다.
+    자주 가는 지역(`FavoriteLocation`) 모델을 위한, 정보를 직렬화하는 시리얼라이저입니다.
+    회원가입 및 프로필 수정 시 사용됩니다.
     """
     class Meta:
         model = FavoriteLocation
         fields: list[str] = ["province", "city", "district"]
+        # 예시 데이터:
+        # {
+        #     "province": "경기도",
+        #     "city": "수원시",
+        #     "district": "장안구"
+        # }
 
 
 class BaseRegisterSerializer(serializers.ModelSerializer):
+    """
+    사용자 회원 가입의 기본 필드를 정의하는 시리얼라이저입니다.
+    손님(Customer) 및 점주(Owner) 회원 가입 시리얼라이저의 기반이 됩니다.
+    """
     password = serializers.CharField(write_only=True, min_length=8)
 
     class Meta:
@@ -44,6 +54,10 @@ class BaseRegisterSerializer(serializers.ModelSerializer):
         }
 
     def validate_password(self, value: str) -> str:
+        """
+        Django의 기본 비밀번호 유효성 검사 규칙을 적용합니다.
+        (예: 최소 길이, 일반적인 비밀번호 사용 여부 등)
+        """
         try:
             validate_password(value)
         except DjangoValidationError as e:
@@ -52,6 +66,12 @@ class BaseRegisterSerializer(serializers.ModelSerializer):
 
     @transaction.atomic
     def create(self, validated_data: dict[str, Any]) -> User:
+        """
+        새로운 사용자를 생성하고, 역할(role)에 따라 추가 정보를 처리합니다.
+
+        - 'role'이 'customer'인 경우: 'favorite_locations'를 생성합니다.
+        - 'role'이 'owner'인 경우: 'place'를 생성합니다.
+        """
         role: str = self.context["role"]
         password: str = validated_data.pop("password")
         favorite_locations_data = validated_data.pop("favorite_locations", [])
@@ -75,21 +95,31 @@ class BaseRegisterSerializer(serializers.ModelSerializer):
 
 
 class RegisterCustomerSerializer(BaseRegisterSerializer):
+    """
+    '손님' 회원의 가입을 처리하는 시리얼라이저입니다.
+    BaseRegisterSerializer를 상속하며, '자주 가는 지역' 필드를 추가합니다.
+
+    - 필수 필드: 'favorite_locations' (최소 1개 이상의 지역 정보)
+    """
     favorite_locations = FavoriteLocationSerializer(
         many=True, required=True, min_length=1
     )
 
     class Meta(BaseRegisterSerializer.Meta):
-        fields = BaseRegisterSerializer.Meta.fields + ("favorite_locations",)
+        fields: tuple[Literal['id'], Literal['username'], Literal['email'], Literal['password'], Literal['phone']] = BaseRegisterSerializer.Meta.fields + ("favorite_locations",)
 
 
 class RegisterOwnerSerializer(BaseRegisterSerializer):
-    # PlaceCreateSerializer를 중첩 시리얼라이저로 추가합니다.
-    # required=True로 설정하여 가게 정보가 필수로 등록되도록 합니다.
+    """
+    '점주' 회원의 가입을 처리하는 시리얼라이저입니다.
+    BaseRegisterSerializer를 상속하며, '가게' 정보 필드를 추가합니다.
+
+    - 필수 필드: 'place' (가게 생성 정보)
+    """
     place = PlaceCreateSerializer(required=True)
 
     class Meta(BaseRegisterSerializer.Meta):
-        fields = BaseRegisterSerializer.Meta.fields + ("place",)
+        fields: tuple[Literal['id'], Literal['username'], Literal['email'], Literal['password'], Literal['phone']] = BaseRegisterSerializer.Meta.fields + ("place",)
 
 
 
@@ -99,7 +129,7 @@ class UserUpdateSerializer(serializers.ModelSerializer):
     `username`, `email`, `phone`, `favorite_locations` 필드를 수정할 수 있습니다.
 
     **특징:**
-    - `email`과 `username`은 업데이트 시 필수가 아닙니다.
+    - 모든 필드는 업데이트 시 필수가 아닙니다.
     - `favorite_locations`를 업데이트하면 기존 데이터는 모두 삭제되고 새로운 데이터로 대체됩니다.
     """
 
@@ -113,13 +143,14 @@ class UserUpdateSerializer(serializers.ModelSerializer):
     @transaction.atomic
     def update(self, instance, validated_data):
         """
-        사용자 프로필과 즐겨찾는 지역 데이터를 업데이트합니다.
+        사용자 프로필과 '자주 가는 지역' 데이터를 업데이트합니다.
 
         **로직:**
         1. 요청 데이터에서 `favorite_locations`를 분리합니다.
         2. `User` 모델 필드(`username`, `email`, `phone`)를 업데이트합니다.
-        3. 기존의 모든 `FavoriteLocation` 데이터를 삭제합니다.
-        4. 새로운 `FavoriteLocation` 데이터로 객체들을 다시 생성합니다.
+        3 'favorite_locations' 데이터가 있는 경우: 기존 데이터를 모두 삭제하고, 새로운 데이터로 재등록합니다.
+        -> 기존의 모든 `FavoriteLocation` 데이터를 삭제합니다.
+        -> 새로운 `FavoriteLocation` 데이터로 객체들을 다시 생성합니다.
         """
         # favorite_locations 데이터 분리
         favorite_locations_data = validated_data.pop("favorite_locations", [])
@@ -130,8 +161,7 @@ class UserUpdateSerializer(serializers.ModelSerializer):
         instance.phone = validated_data.get("phone", instance.phone)
         instance.save()
 
-        # 기존 favorite_locations 데이터 모두 삭제 후,
-        # 새로운 데이터로 다시 생성
+        # 'favorite_locations'가 요청에 포함된 경우에만 업데이트 로직 실행
         if favorite_locations_data:
             instance.favorite_locations.all().delete()
             for location_data in favorite_locations_data:
@@ -142,7 +172,10 @@ class UserUpdateSerializer(serializers.ModelSerializer):
 
 class UserMiniSerializer(serializers.ModelSerializer):
     """
-    JWT 토큰 응답에 포함될 최소한의 사용자 정보 시리얼라이저입니다.
+    JWT 토큰 응답에 포함될 최소한의 사용자 정보를 직렬화하는 시리얼라이저입니다.
+    로그인 성공 시 반환되는 데이터 구조를 정의합니다.
+
+    - 출력 필드: 'id', 'username', 'role'
     """
 
     class Meta:
@@ -156,26 +189,27 @@ class UserMiniSerializer(serializers.ModelSerializer):
 
 class MeSerializer(serializers.ModelSerializer):
     """
-    `MeView` (내 프로필 조회)를 위한 시리얼라이저입니다.
-    사용자의 기본 정보(`id`, `username`, `email`, `role`)와
-    연결된 자주 가는 지역(`favorite_locations`) 정보를 함께 반환합니다.
+    로그인한 사용자의 상세 프로필 정보를 조회하기 위한 시리얼라이저입니다.
+    `MeView` (내 프로필 조회) API에 사용됩니다.
+
+    - 출력 필드: 'id', 'username', 'email', 'role'
+    - 추가 필드: 'favorite_locations' (손님인 경우), 'place' (점주인 경우)
     """
 
     favorite_locations = FavoriteLocationSerializer(many=True, read_only=True)
 
-    # 점주인 경우 가게 정보를 함께 반환하도록 PlaceSerializer를 추가합니다.
-    # -------------여기 추가--------------
     place = serializers.SerializerMethodField()
 
     def get_place(self, obj: User) -> dict | None:
         """
         사용자가 점주인 경우, 연결된 가게 정보를 반환합니다.
+        가게 정보가 없는 경우 'None'을 반환합니다.
         """
         if not obj.is_owner():
             return None
         try:
             place = obj.place  # 없으면 Place.DoesNotExist 발생
-        except place.DoesNotExist:
+        except Place.DoesNotExist:
             return None
         return PlaceSerializer(place).data
     

--- a/modelproject/accounts/signals.py
+++ b/modelproject/accounts/signals.py
@@ -8,9 +8,19 @@ from couponbook.models import CouponBook
 @receiver(post_save, sender=User)
 def create_coupon_book(sender, instance, created, **kwargs):
     """
-    새로운 User 객체가 생성될 때, 해당 사용자가 손님(CUSTOMER)인 경우에만
-    CouponBook을 자동으로 생성하는 시그널 핸들러입니다.
+    새로운 User 객체가 생성된 후(post_save), 해당 사용자가 손님(customer)인 경우
+    couponbook을 자동으로 생성하는 시그널 핸들러입니다.
+
+    Args:
+        sender (Model): 시그널을 보낸 모델. 여기서는 User 모델입니다.
+        instance (User): 방금 생성되거나 업데이트된 User 인스턴스입니다.
+        created (bool): 새로운 객체가 생성되었을 때 True입니다.
+        **kwargs: 추가적인 키워드 인수입니다.
+
+    Returns:
+        None
     """
+    # 사용자가 방금 생성되었고, 역할이 'customer'인 경우에만 실행됩니다.
     if created and instance.is_customer():
         # CouponBook 인스턴스를 생성하고, 외래키(ForeignKey) 필드에 새로 생성된 user를 할당
         try:
@@ -18,5 +28,4 @@ def create_coupon_book(sender, instance, created, **kwargs):
 
         except Exception as e:
             # 예외가 발생하면 로깅을 남겨 디버깅에 도움
-
             print(f"Error creating CouponBook for user {instance.username}: {e}")

--- a/modelproject/accounts/urls.py
+++ b/modelproject/accounts/urls.py
@@ -1,3 +1,21 @@
+"""
+Accounts 앱 URLConf.
+
+이 파일은 `urls.py` 파일로, `accounts` 앱의 URL 라우팅을 담당합니다.
+프로젝트의 메인 `urls.py`에서 `path("accounts/", include("accounts.urls"))`와 같이
+포함되는 것을 전제로 합니다.
+
+즉, 각 엔드포인트의 전체 경로는 다음과 같습니다:
+- 손님 회원가입: POST /accounts/auth/register/customer
+- 점주 회원가입: POST /accounts/auth/register/owner
+- 로그인: POST /accounts/auth/login
+- 로그아웃: POST /accounts/auth/logout
+- 토큰 재발급: POST /accounts/auth/refresh
+- 내 프로필 조회: GET /accounts/auth/me
+- 마이페이지 프로필 수정: PUT/PATCH /accounts/profile
+- 회원 탈퇴: POST /accounts/deactivate
+"""
+
 from django.urls import path
 
 from .views import (
@@ -24,10 +42,10 @@ urlpatterns: list = [
     ),  # 점주 회원가입
     path("auth/login", LoginView.as_view(), name="login"),  # 로그인
     path("auth/logout", LogoutView.as_view(), name="logout"),  # 로그아웃
+    path("auth/refresh", RefreshView.as_view(), name="refresh"),  # Access 토큰 재발급
     path(
         "deactivate", UserDeactivateView.as_view(), name="user-deactivate"
     ),  # 회원 탈퇴
-    path("auth/refresh", RefreshView.as_view(), name="refresh"),  # Refresh 발급
     path("auth/me", MeView.as_view(), name="me"),  # 신규 보호 엔드포인트
     path(
         "profile", UserProfileView.as_view(), name="user-profile"

--- a/modelproject/accounts/urls.py
+++ b/modelproject/accounts/urls.py
@@ -33,21 +33,21 @@ app_name = "accounts"
 
 urlpatterns: list = [
     path(
-        "auth/register/customer",
+        "auth/register/customer/",
         RegisterCustomerView.as_view(),
-        name="register-customer",
+        name="register-customer/",
     ),  # 손님 회원가입
     path(
-        "auth/register/owner", RegisterOwnerView.as_view(), name="register-owner"
+        "auth/register/owner/", RegisterOwnerView.as_view(), name="register-owner"
     ),  # 점주 회원가입
-    path("auth/login", LoginView.as_view(), name="login"),  # 로그인
-    path("auth/logout", LogoutView.as_view(), name="logout"),  # 로그아웃
-    path("auth/refresh", RefreshView.as_view(), name="refresh"),  # Access 토큰 재발급
+    path("auth/login/", LoginView.as_view(), name="login"),  # 로그인
+    path("auth/logout/", LogoutView.as_view(), name="logout"),  # 로그아웃
+    path("auth/refresh/", RefreshView.as_view(), name="refresh"),  # Access 토큰 재발급
     path(
         "deactivate", UserDeactivateView.as_view(), name="user-deactivate"
     ),  # 회원 탈퇴
-    path("auth/me", MeView.as_view(), name="me"),  # 신규 보호 엔드포인트
+    path("auth/me/", MeView.as_view(), name="me"),  # 신규 보호 엔드포인트
     path(
-        "profile", UserProfileView.as_view(), name="user-profile"
+        "profile/", UserProfileView.as_view(), name="user-profile"
     ),  # 마이페이지 프로필 조회/수정
 ]

--- a/modelproject/accounts/urls.py
+++ b/modelproject/accounts/urls.py
@@ -28,7 +28,7 @@ urlpatterns: list = [
         "deactivate", UserDeactivateView.as_view(), name="user-deactivate"
     ),  # 회원 탈퇴
     path("auth/refresh", RefreshView.as_view(), name="refresh"),  # Refresh 발급
-    path("auth/me", MeView.as_view()),  # 신규 보호 엔드포인트
+    path("auth/me", MeView.as_view(), name="me"),  # 신규 보호 엔드포인트
     path(
         "profile", UserProfileView.as_view(), name="user-profile"
     ),  # 마이페이지 프로필 조회/수정

--- a/modelproject/accounts/views.py
+++ b/modelproject/accounts/views.py
@@ -35,6 +35,7 @@ User: type[AbstractUser] = get_user_model()
     """,
     request=RegisterCustomerSerializer,
     responses={201: RegisterCustomerSerializer},
+    auth=None,
     examples=[
         OpenApiExample(
             "손님 회원가입 예시",
@@ -61,6 +62,7 @@ class RegisterCustomerView(APIView):
 
     # DRF 브라우저에서 JSON/폼 모두 받을 수 있도록 파서 명시
     parser_classes: tuple[type[JSONParser], type[FormParser], type[MultiPartParser]] = (JSONParser, FormParser, MultiPartParser)
+    authentication_classes: tuple = ()
 
     def post(self, request: Request) -> Response:
         """
@@ -87,6 +89,7 @@ class RegisterCustomerView(APIView):
     """,
     request=RegisterOwnerSerializer,
     responses={201: RegisterOwnerSerializer},
+    auth=None,
     # 점주 회원가입 예시 -> Customer와 동일
 )
 class RegisterOwnerView(APIView):
@@ -101,6 +104,7 @@ class RegisterOwnerView(APIView):
         FormParser,
         MultiPartParser,
     )
+    authentication_classes: tuple = ()
 
     def post(self, request: Request) -> Response:
         """
@@ -137,6 +141,7 @@ class RegisterOwnerView(APIView):
             "username 직접", value={"username": "alice", "password": "P@ssw0rd!"}
         ),
     ],
+    auth=None,
 )
 class LoginView(TokenObtainPairView):
     """
@@ -146,7 +151,7 @@ class LoginView(TokenObtainPairView):
     성공 시, 클라이언트는 `access`와 `refresh` 토큰을 응답으로 받게 됩니다.
     `access` 토큰은 보호된 API에 접근할 때 사용되며, `refresh` 토큰은 `access` 토큰이 만료되었을 때 재발급받는 데 사용됩니다.
     """
-
+    authentication_classes: tuple = ()
     serializer_class = IdentifierTokenObtainPairSerializer
 
 # ------------------------ Access 토큰 재발급 -------------------------
@@ -163,6 +168,7 @@ class LoginView(TokenObtainPairView):
         200: {"description": "새로운 Access 토큰 발급", "content": {"application/json": {"examples": {"success": {"value": {"access": "new_access_token_here", "refresh": "your_refresh_token_here"}}}}}},
         401: {"description": "유효하지 않은 토큰"},
     },
+    auth=None,
 )
 class RefreshView(TokenRefreshView):
     """
@@ -172,7 +178,7 @@ class RefreshView(TokenRefreshView):
     요청 본문(JSON):
         - `refresh`: 기존에 발급받은 Refresh 토큰
     """
-
+    authentication_classes: tuple = ()
     pass
 
 # ------------------------ 사용자 정보 조회 -------------------------

--- a/modelproject/accounts/views.py
+++ b/modelproject/accounts/views.py
@@ -25,7 +25,7 @@ from .serializers import (
 
 User: type[AbstractUser] = get_user_model()
 
-
+# ------------------------ 손님 회원가입 -------------------------
 @extend_schema(
     tags=["Auth"],
     summary="손님 회원가입",
@@ -76,7 +76,7 @@ class RegisterCustomerView(APIView):
         # 비밀번호는 write_only 이므로 응답에 포함되지 않음
         return Response(RegisterCustomerSerializer(user).data, status=status.HTTP_201_CREATED)
 
-
+# ------------------------ 점주 회원가입 -------------------------
 @extend_schema(
     tags=["Auth"],
     summary="점주 회원가입",
@@ -114,6 +114,7 @@ class RegisterOwnerView(APIView):
         user = serializer.save()
         return Response(RegisterOwnerSerializer(user).data, status=status.HTTP_201_CREATED)
 
+# ------------------------ 로그인 -------------------------
 @extend_schema(
     tags=["Auth"],
     summary="로그인 (username 또는 email + password)",
@@ -148,7 +149,7 @@ class LoginView(TokenObtainPairView):
 
     serializer_class = IdentifierTokenObtainPairSerializer
 
-
+# ------------------------ Access 토큰 재발급 -------------------------
 @extend_schema(
     tags=["Auth"],
     summary="Access 토큰 재발급",
@@ -174,7 +175,7 @@ class RefreshView(TokenRefreshView):
 
     pass
 
-
+# ------------------------ 사용자 정보 조회 -------------------------
 @extend_schema(
     tags=["Auth"],
     summary="내 프로필 조회 (로그인 필수))",
@@ -209,7 +210,7 @@ class MeView(APIView):
         serializer = MeSerializer(user)
         return Response(serializer.data, status=status.HTTP_200_OK)
 
-
+# ------------------------ 마이페이지 프로필 조회 및 수정 -------------------------
 @extend_schema(
     tags=["User"],
     summary="내 프로필 조회 및 수정 (로그인 필수)",
@@ -233,7 +234,7 @@ class UserProfileView(generics.RetrieveUpdateAPIView):
         """
         return self.request.user
 
-
+# ------------------------ 로그아웃 -------------------------
 @extend_schema(
     tags=["Auth"],
     summary="로그아웃",
@@ -301,7 +302,7 @@ class LogoutView(APIView):
                 status=status.HTTP_400_BAD_REQUEST,
             )
 
-
+# ------------------------ 회원 탈퇴 -------------------------
 @extend_schema(
     tags=["User"],
     summary="회원 탈퇴",

--- a/modelproject/accounts/views.py
+++ b/modelproject/accounts/views.py
@@ -9,18 +9,16 @@ from rest_framework.permissions import IsAuthenticated
 from rest_framework.request import Request
 from rest_framework.response import Response
 from rest_framework.views import APIView
-from rest_framework_simplejwt.token_blacklist.models import (
-    BlacklistedToken,
-    OutstandingToken,
-)
+from rest_framework_simplejwt.token_blacklist.models import BlacklistedToken,OutstandingToken
+
 from rest_framework_simplejwt.tokens import RefreshToken, TokenError
 from rest_framework_simplejwt.views import TokenObtainPairView, TokenRefreshView
 
 from .auth_utils import IdentifierTokenObtainPairSerializer
-from .models import FavoriteLocation
 from .serializers import (
     MeSerializer,
-    RegisterSerializer,
+    RegisterCustomerSerializer,
+    RegisterOwnerSerializer,
     UserMiniSerializer,
     UserUpdateSerializer,
 )
@@ -31,8 +29,8 @@ User: type[AbstractUser] = get_user_model()
 @extend_schema(
     tags=["Auth"],
     summary="손님 회원가입",
-    request=RegisterSerializer,
-    responses={201: RegisterSerializer},
+    request=RegisterCustomerSerializer,
+    responses={201: RegisterCustomerSerializer},
     examples=[
         OpenApiExample(
             "손님 회원가입 예시",
@@ -63,23 +61,23 @@ class RegisterCustomerView(APIView):
     def post(self, request: Request) -> Response:
         """
         새로운 손님 사용자를 생성합니다.
-        `RegisterSerializer`를 사용해 요청 데이터를 검증하고, `CUSTOMER` 역할을 할당합니다.
+        `RegisterCustomerSerializer`를 사용해 요청 데이터를 검증하고, `CUSTOMER` 역할을 할당합니다.
         """
-        serializer = RegisterSerializer(
+        serializer = RegisterCustomerSerializer(
             data=request.data, context={"role": User.Role.CUSTOMER}
         )
         serializer.is_valid(raise_exception=True)
         user = serializer.save()
 
         # 비밀번호는 write_only 이므로 응답에 포함되지 않음
-        return Response(RegisterSerializer(user).data, status=status.HTTP_201_CREATED)
+        return Response(RegisterCustomerSerializer(user).data, status=status.HTTP_201_CREATED)
 
 
 @extend_schema(
     tags=["Auth"],
     summary="점주 회원가입",
-    request=RegisterSerializer,
-    responses={201: RegisterSerializer},
+    request=RegisterOwnerSerializer,
+    responses={201: RegisterOwnerSerializer},
     # 점주 회원가입 예시 -> Customer와 동일
 )
 class RegisterOwnerView(APIView):
@@ -99,15 +97,15 @@ class RegisterOwnerView(APIView):
     def post(self, request: Request) -> Response:
         """
         새로운 점주 사용자를 생성합니다.
-        `RegisterSerializer`를 사용해 요청 데이터를 검증하고, `OWNER` 역할을 할당합니다.
+        `RegisterOwnerSerializer`를 사용해 요청 데이터를 검증하고, `OWNER` 역할을 할당합니다.
         """
-        serializer = RegisterSerializer(
+        serializer = RegisterOwnerSerializer(
             data=request.data, context={"role": User.Role.OWNER}
         )
         serializer.is_valid(raise_exception=True)
         user = serializer.save()
-        return Response(RegisterSerializer(user).data, status=status.HTTP_201_CREATED)
-
+        return Response(RegisterOwnerSerializer(user).data, status=status.HTTP_201_CREATED)
+# -> 여기 수정 ------------------------
 
 @extend_schema(
     tags=["Auth"],

--- a/modelproject/couponbook/apps.py
+++ b/modelproject/couponbook/apps.py
@@ -5,5 +5,5 @@ class CouponbookConfig(AppConfig):
     default_auto_field = 'django.db.models.BigAutoField'
     name = 'couponbook'
 
-    def ready(self):
+    def ready(self) -> None:
         from . import signals

--- a/modelproject/couponbook/models.py
+++ b/modelproject/couponbook/models.py
@@ -48,8 +48,6 @@ class CouponTemplate(models.Model):
     # Todo: views 시리얼라이저 필드로 이동
     views = models.PositiveIntegerField(default=0, help_text="조회수를 의미합니다.")
     # 쿠폰 템플릿이 어느 가게에 속하는지 명시적으로 연결합니다.
-    # place = models.ForeignKey('Place', on_delete=models.CASCADE, related_name='coupon_templates')
-    """여기 추가"""
     created_at = models.DateTimeField(auto_now_add=True, help_text="점주가 쿠폰 템플릿을 등록한 날짜와 시간입니다.")
     place = models.ForeignKey("couponbook.Place",
                               related_name='coupon_templates',
@@ -104,7 +102,5 @@ class Place(models.Model):
     # todo: 영업하는 요일 필드 추가
     last_order = models.TimeField(help_text="라스트오더 시간입니다.")
     tel = models.CharField(max_length=20, help_text="가게 전화번호입니다.")
-    
+    # 점주와 가게를 1:1로 연결
     owner = models.OneToOneField("accounts.User", on_delete=models.CASCADE, related_name="place", null=True, blank=True, help_text="이 매장의 점주 사용자입니다.")
-    """여기 추가
-    점주와 가게를 1:1로 연결"""

--- a/modelproject/couponbook/models.py
+++ b/modelproject/couponbook/models.py
@@ -42,17 +42,22 @@ class CouponTemplate(models.Model):
     """
     점주가 등록해서 게시중인 쿠폰 템플릿입니다.
     """
-    valid_until = models.DateTimeField(default=None, help_text="쿠폰의 유효기간입니다.")
+    valid_until = models.DateTimeField(null=True, blank=True, help_text="쿠폰의 유효기간입니다.")
     first_n_persons = models.PositiveIntegerField(default=0, help_text="선착순 몇명까지 쿠폰이 발급한지를 의미합니다.")
     is_on = models.BooleanField(default=True, help_text="게시 중/비공개 여부를 불리언으로 나타냅니다.")
     # Todo: views 시리얼라이저 필드로 이동
     views = models.PositiveIntegerField(default=0, help_text="조회수를 의미합니다.")
+    # 쿠폰 템플릿이 어느 가게에 속하는지 명시적으로 연결합니다.
+    # place = models.ForeignKey('Place', on_delete=models.CASCADE, related_name='coupon_templates')
+    """여기 추가"""
     created_at = models.DateTimeField(auto_now_add=True, help_text="점주가 쿠폰 템플릿을 등록한 날짜와 시간입니다.")
     place = models.ForeignKey("couponbook.Place",
                               related_name='coupon_templates',
                               on_delete=models.CASCADE,
                               help_text="해당 쿠폰과 연관된 매장 id입니다.",
-                              null=True)
+                              null=False,
+                              blank=False,
+                              )
 
 class RewardsInfo(models.Model):
     """
@@ -99,3 +104,7 @@ class Place(models.Model):
     # todo: 영업하는 요일 필드 추가
     last_order = models.TimeField(help_text="라스트오더 시간입니다.")
     tel = models.CharField(max_length=20, help_text="가게 전화번호입니다.")
+    
+    owner = models.OneToOneField("accounts.User", on_delete=models.CASCADE, related_name="place", null=True, blank=True, help_text="이 매장의 점주 사용자입니다.")
+    """여기 추가
+    점주와 가게를 1:1로 연결"""

--- a/modelproject/couponbook/serializers.py
+++ b/modelproject/couponbook/serializers.py
@@ -1,8 +1,11 @@
 from django.shortcuts import get_object_or_404
 from django.utils.timezone import now
 from drf_spectacular.types import OpenApiTypes
-from drf_spectacular.utils import (OpenApiExample, extend_schema_field,
-                                   extend_schema_serializer)
+from drf_spectacular.utils import (
+    OpenApiExample,
+    extend_schema_field,
+    extend_schema_serializer,
+)
 from rest_framework import serializers
 from rest_framework.reverse import reverse
 
@@ -10,179 +13,234 @@ from .models import *
 
 # 시리얼라이저는 역순으로 정의되어 있습니다.
 
-DATETIME_FORMAT = "%Y-%m-%d %H:%M" # 기본 datetime 출력 포맷
-TIME_FORMAT = "%H:%M" # 기본 time 출력 포맷
+DATETIME_FORMAT = "%Y-%m-%d %H:%M"  # 기본 datetime 출력 포맷
+TIME_FORMAT = "%H:%M"  # 기본 time 출력 포맷
+
 
 # -------------------------- 스탬프 ----------------------------------
-@extend_schema_serializer(
-    examples=[
-        OpenApiExample("예시",
-                       {'receipt': '01234567890'})
-    ]
-)
+@extend_schema_serializer(examples=[OpenApiExample("예시", {"receipt": "01234567890"})])
+# class StampListRequestSerializer(serializers.ModelSerializer):
+#     """
+#     스탬프를 생성(적립)하는 데에 사용되는 시리얼라이저입니다. 입력받은 영수증 번호를 바탕으로 스탬프를 생성합니다.
+#     """
+
+#     def validate(self, data) -> dict:
+#         """
+#         1. 영수증 번호가 등록되어 있는 영수증인지 확인합니다.
+#         2. 영수증 번호에 해당하는 스탬프가 이미 등록되어 있는지 확인합니다.
+
+#         둘 중 하나라도 만족하지 못하면 ValidationError가 발생합니다.
+#         """
+#         receipt = data.get("receipt")
+#         if not receipt:
+#             raise serializers.ValidationError("DB에 등록되지 않은 영수증 번호입니다.")
+
+#         if hasattr(receipt, "stamp"):
+#             raise serializers.ValidationError("이미 스탬프가 발급된 영수증 번호입니다.")
+
+#         return super().validate(data)
+
+#     def create(self, validated_data) -> Stamp:
+#         """
+#         유효성 검증을 통과한 영수증 번호를 바탕으로 쿠폰 id와 유저를 바탕으로 스탬프 인스턴스를 생성하고 돌려줍니다.
+#         """
+#         receipt = validated_data.pop("receipt")
+#         coupon_id = self.context["coupon_id"]
+#         user = self.context["request"].user
+
+#         return Stamp.objects.create(receipt=receipt, coupon_id=coupon_id, customer=user)
+
+#     class Meta:
+#         model = Stamp
+#         fields = ["receipt"]
 class StampListRequestSerializer(serializers.ModelSerializer):
     """
-    스탬프를 생성(적립)하는 데에 사용되는 시리얼라이저입니다. 입력받은 영수증 번호를 바탕으로 스탬프를 생성합니다.
+    영수증 번호 문자열을 받아 Receipt를 조회/자동 생성 후 Stamp를 만듭니다.
     """
+    receipt_number = serializers.CharField(write_only=True)
 
-    def validate(self, data) -> dict:
-        """
-        1. 영수증 번호가 등록되어 있는 영수증인지 확인합니다.
-        2. 영수증 번호에 해당하는 스탬프가 이미 등록되어 있는지 확인합니다.
-
-        둘 중 하나라도 만족하지 못하면 ValidationError가 발생합니다.
-        """
-        receipt = data.get('receipt')
-        if not receipt:
-            raise serializers.ValidationError("DB에 등록되지 않은 영수증 번호입니다.")
-        
-        if hasattr(receipt, 'stamp'):
-            raise serializers.ValidationError("이미 스탬프가 발급된 영수증 번호입니다.")
-
-        return super().validate(data)
-    
-    def create(self, validated_data) -> Stamp:
-        """
-        유효성 검증을 통과한 영수증 번호를 바탕으로 쿠폰 id와 유저를 바탕으로 스탬프 인스턴스를 생성하고 돌려줍니다.
-        """
-        receipt = validated_data.pop('receipt')
-        coupon_id = self.context['coupon_id']
-        user = self.context['request'].user
-
-        return Stamp.objects.create(receipt=receipt, coupon_id=coupon_id, customer=user)
-    
     class Meta:
-        model = Stamp 
-        fields = ['receipt']
+        model = Stamp
+        fields = ["receipt_number"]
+
+    def validate(self, data):
+        num = data.get("receipt_number")
+        if not num:
+            raise serializers.ValidationError({"receipt_number": "영수증 번호가 필요합니다."})
+        # 정책 1: 없는 번호는 자동 생성
+        receipt, _ = Receipt.objects.get_or_create(receipt_number=num)
+        # 정책 2: 이미 사용된 영수증이면 거절
+        if hasattr(receipt, "stamp"):
+            raise serializers.ValidationError({"receipt_number": "이미 스탬프가 발급된 영수증 번호입니다."})
+        data["receipt"] = receipt
+        return data
+
+    def create(self, validated_data):
+        validated_data.pop("receipt_number", None)
+        receipt = validated_data.pop("receipt")
+        coupon_id = self.context["coupon_id"]
+        user = self.context["request"].user
+        return Stamp.objects.create(receipt=receipt, coupon_id=coupon_id, customer=user)
+
 
 @extend_schema_serializer(
     examples=[
-        OpenApiExample("예시",
-                       {'id': 1,
-                        'stamp_url': 'http://localhost:8000/couponbook/stamps/1'})
+        OpenApiExample(
+            "예시", {"id": 1, "stamp_url": "http://localhost:8000/couponbook/stamps/1"}
+        )
     ]
 )
 class StampListResponseSerializer(serializers.ModelSerializer):
     """
     스탬프의 목록을 조회하는 응답에 사용되는 시리얼라이저입니다.
     """
+
     stamp_url = serializers.SerializerMethodField()
-    
+
     @extend_schema_field(OpenApiTypes.URI)
     def get_stamp_url(self, obj: Stamp):
         """
         개별 스탬프의 URL입니다.
         """
-        request = self.context['request']
-        return reverse('couponbook:stamp-detail', kwargs={'stamp_id': obj.id}, request=request)
-    
+        request = self.context["request"]
+        return reverse(
+            "couponbook:stamp-detail", kwargs={"stamp_id": obj.id}, request=request
+        )
+
     class Meta:
         model = Stamp
-        fields = ['id', 'stamp_url']
+        fields = ["id", "stamp_url"]
+
 
 @extend_schema_serializer(
-    examples=[
-        OpenApiExample("예시",
-                       {'id': 1,
-                        'created_at': '2025-08-18 21:00'})
-    ]
+    examples=[OpenApiExample("예시", {"id": 1, "created_at": "2025-08-18 21:00"})]
 )
 class StampDetailResponseSerializer(serializers.ModelSerializer):
     """
     한 스탬프의 정보를 조회하는 응답에 사용되는 시리얼라이저입니다.
     """
+
     created_at = serializers.DateTimeField(DATETIME_FORMAT)
+
     class Meta:
         model = Stamp
-        fields = ['id', 'created_at']
+        fields = ["id", "created_at"]
 
 
 # ------------------------ 혜택 정보 ---------------------------
 @extend_schema_serializer(
-    examples=[
-        OpenApiExample("예시",
-                       {'amount': 10,
-                        'reward': '아메리카노 1잔 무료'})
-    ]
+    examples=[OpenApiExample("예시", {"amount": 10, "reward": "아메리카노 1잔 무료"})]
 )
 class RewardsInfoDetailSerializer(serializers.ModelSerializer):
     """
     쿠폰에 해당하는 혜택 정보를 조회하는 시리얼라이저입니댜.
     """
+
     class Meta:
         model = RewardsInfo
-        exclude = ['id', 'coupon_template']
+        exclude = ["id", "coupon_template"]
 
 
 # ---------------------------- 가게 ---------------------------------------
 @extend_schema_serializer(
     examples=[
-        OpenApiExample("예시",
-                       {'id': 1,
-                        'name': '매머드 커피',
-                        'address': '서울 동대문구 이문동 264-223',
-                        'image_url': 'http://localhost:8000',
-                        'opens_at': '`08:00',
-                        'closes_at': '21:00',
-                        'last_order': '20:30',
-                        'tel': '0507-1361-0962',})
+        OpenApiExample(
+            "예시",
+            {
+                "id": 1,
+                "name": "매머드 커피",
+                "address": "서울 동대문구 이문동 264-223",
+                "image_url": "http://localhost:8000",
+                "opens_at": "08:00",
+                "closes_at": "21:00",
+                "last_order": "20:30",
+                "tel": "0507-1361-0962",
+            },
+        )
     ]
 )
 class PlaceDetailResponseSerializer(serializers.ModelSerializer):
     """
     가게 정보를 조회하는 응답에 사용되는 시리얼라이저입니다.
     """
+
     opens_at = serializers.TimeField(TIME_FORMAT)
     closes_at = serializers.TimeField(TIME_FORMAT)
     last_order = serializers.TimeField(TIME_FORMAT)
 
     class Meta:
         model = Place
-        fields = '__all__'
+        fields = "__all__"
+
+
+# 여기 추가
+class PlaceSerializer(serializers.ModelSerializer):
+    """
+    가게(Place) 정보를 조회할 때 사용하는 시리얼라이저입니다.
+    """
+
+    class Meta:
+        model = Place
+        fields = ["id", "name", "address", "opens_at", "closes_at", "last_order", "tel"]
+
+
+class PlaceCreateSerializer(serializers.ModelSerializer):
+    """
+    가게를 생성할 때 사용하는 시리얼라이저입니다.
+    """
+
+    class Meta:
+        model = Place
+        # owner 필드는 accounts/serializers.py에서 자동으로 처리
+        fields = ["name", "address", "image_url", "opens_at", "closes_at", "last_order", "tel"]
 
 
 # ------------------------ 쿠폰 템플릿 -------------------------
 @extend_schema_serializer(
     examples=[
-        OpenApiExample("예시",
-                       {'id': 1,
-                        'max_stamps': 10,
-                        'saves': 5,
-                        'uses': 2,
-                        'valid_until': '2025-11-11 23:59',
-                        'first_n_persons': 50,
-                        'is_on': True,
-                        'views': 8,
-                        'created_at': '2025-08-18 21:30',})
+        OpenApiExample(
+            "예시",
+            {
+                "id": 1,
+                "max_stamps": 10,
+                "saves": 5,
+                "uses": 2,
+                "valid_until": "2025-11-11 23:59",
+                "first_n_persons": 50,
+                "is_on": True,
+                "views": 8,
+                "created_at": "2025-08-18 21:30",
+            },
+        )
     ]
 )
 class CouponTemplateListSerializer(serializers.ModelSerializer):
     """
     점주가 등록하여 게시중인 쿠폰 템플릿을 조회하는 시리얼라이저입니다.
     """
+
     place = PlaceDetailResponseSerializer()
     reward_info = RewardsInfoDetailSerializer()
     max_stamps = serializers.SerializerMethodField()
     saves = serializers.SerializerMethodField()
     uses = serializers.SerializerMethodField()
-    valid_until = serializers.DateTimeField(DATETIME_FORMAT)
+    valid_until = serializers.DateTimeField(DATETIME_FORMAT, allow_null=True, required=False)
     created_at = serializers.DateTimeField(DATETIME_FORMAT)
 
     def get_max_stamps(self, obj: CouponTemplate) -> int:
         """
         리워드를 받을 수 있는 스탬프 개수입니다.
         """
-        reward_info = obj.reward_info
-        max_stamps = reward_info.amount
-        return max_stamps
-    
+        reward_info = getattr(obj, "reward_info", None)
+        return reward_info.amount if reward_info else 0
+
     def get_saves(self, obj: CouponTemplate) -> int:
         """
         유저 전체의 쿠폰북 기준으로 해당 쿠폰 템플릿으로 생성한 실사용 쿠폰이 저장되어 있는 횟수입니다.
         """
         saved_coupons = Coupon.objects.filter(original_template=obj)
         return saved_coupons.count()
-    
+
     def get_uses(self, obj: CouponTemplate) -> int:
         """
         해당 쿠폰 템플릿으로 생성한 실사용 쿠폰으로 적립된 스탬프의 개수입니다.
@@ -195,27 +253,33 @@ class CouponTemplateListSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = CouponTemplate
-        fields = '__all__'
+        fields = "__all__"
+
 
 @extend_schema_serializer(
     examples=[
-        OpenApiExample("예시",
-                       {'id': 1,
-                        'max_stamps': 10,
-                        'current_n_remaining': 45,
-                        'valid_until': '2025-11-11 23:59',
-                        'first_n_persons': 50,
-                        'created_at': '2025-08-18 21:30',})
+        OpenApiExample(
+            "예시",
+            {
+                "id": 1,
+                "max_stamps": 10,
+                "current_n_remaining": 45,
+                "valid_until": "2025-11-11 23:59",
+                "first_n_persons": 50,
+                "created_at": "2025-08-18 21:30",
+            },
+        )
     ]
 )
 class CouponTemplateDetailSerializer(serializers.ModelSerializer):
     """
     개별 쿠폰 템플릿을 조회하는 응답에 사용되는 시리얼라이저입니다.
     """
+
     reward_info = RewardsInfoDetailSerializer()
     max_stamps = serializers.SerializerMethodField()
     current_n_remaining = serializers.SerializerMethodField()
-    valid_until = serializers.DateTimeField(DATETIME_FORMAT)
+    valid_until = serializers.DateTimeField(DATETIME_FORMAT, allow_null=True, required=False)
     place = PlaceDetailResponseSerializer()
     created_at = serializers.DateTimeField(DATETIME_FORMAT)
 
@@ -223,27 +287,53 @@ class CouponTemplateDetailSerializer(serializers.ModelSerializer):
         """
         리워드를 받을 수 있는 스탬프 개수입니다.
         """
-        reward_info = obj.reward_info
-        max_stamps = reward_info.amount
-        return max_stamps
-    
+        reward_info = getattr(obj, "reward_info", None)
+        return reward_info.amount if reward_info else 0
+
     def get_current_n_remaining(self, obj: CouponTemplate) -> int:
         """
         현재 기준으로 쿠폰을 발급받을 수 있는 인원 수입니다.
         """
         coupons = obj.coupons
-        return obj.first_n_persons - coupons.count()
+        return max(0, obj.first_n_persons - coupons.count()) # current_n_remaining 이 음수가 될 수 있어 0으로 바닥 고정
 
     class Meta:
         model = CouponTemplate
-        exclude = ['is_on', 'views']
+        exclude = ["is_on", "views"]
 
+
+"""여기 추가"""
+
+
+class CouponTemplateCreateSerializer(serializers.ModelSerializer):
+    """
+    점주가 새로운 쿠폰 템플릿을 등록할 때 사용하는 시리얼라이저입니다.
+    `place` 필드는 뷰에서 현재 로그인된 점주와 연결된 가게 정보로 자동 할당됩니다.
+    """
+
+    reward_info = RewardsInfoDetailSerializer(write_only=True, required=True)
+    valid_until = serializers.DateTimeField(required=False, allow_null=True)
+
+    class Meta:
+        model = CouponTemplate
+        # place 필드는 뷰에서 처리하므로 제외
+        exclude = ["id", "place", "views", "created_at"]
+
+    def create(self, validated_data):
+        reward = validated_data.pop("reward_info")  # required=True 이므로 존재 보장
+        template = CouponTemplate.objects.create(**validated_data)
+        RewardsInfo.objects.create(coupon_template=template, **reward)
+        return template
 
 # --------------------------- 쿠폰 -----------------------------
 @extend_schema_serializer(
     examples=[
-        OpenApiExample("예시",
-                       {'original_template': 1,})
+        OpenApiExample(
+            "예시",
+            {
+                "original_template": 1,
+            },
+        )
     ]
 )
 class CouponListRequestSerializer(serializers.ModelSerializer):
@@ -256,49 +346,60 @@ class CouponListRequestSerializer(serializers.ModelSerializer):
         1. 원본 쿠폰 템플릿이 존재하는지 확인합니다.
         2. 이미 해당 유저가 해당 쿠폰 템플릿으로 등록한 쿠폰이 존재하는지 확인합니다.
         """
-        original_template = data.get('original_template')
+        original_template = data.get("original_template")
         if not original_template:
             raise serializers.ValidationError("해당 쿠폰 템플릿이 존재하지 않습니다.")
-        
-        couponbook = self.context['couponbook']
-        coupon = Coupon.objects.filter(couponbook=couponbook, original_template=original_template)
+
+        couponbook = self.context["couponbook"]
+        coupon = Coupon.objects.filter(
+            couponbook=couponbook, original_template=original_template
+        )
 
         if coupon.exists():
-            raise serializers.ValidationError("이미 해당 쿠폰 템플릿으로 생성한 쿠폰이 존재합니다.")
-        
+            raise serializers.ValidationError(
+                "이미 해당 쿠폰 템플릿으로 생성한 쿠폰이 존재합니다."
+            )
+
         return super().validate(data)
-    
+
     def create(self, validated_data) -> Coupon:
         """
         원본 쿠폰 템플릿을 바탕으로 실사용 쿠폰을 생성합니다.
         """
-        original_template = validated_data.pop('original_template')
-        couponbook = self.context['couponbook']
-        
-        return Coupon.objects.create(couponbook=couponbook, original_template=original_template)
-            
+        original_template = validated_data.pop("original_template")
+        couponbook = self.context["couponbook"]
+
+        return Coupon.objects.create(
+            couponbook=couponbook, original_template=original_template
+        )
 
     class Meta:
         model = Coupon
-        fields = ['original_template']
+        fields = ["original_template"]
+
 
 @extend_schema_serializer(
     examples=[
-        OpenApiExample("예시",
-                       {'id': 1,
-                        'coupon_url': 'http://localhost:8000/couponbook/coupons/1',
-                        'is_favorite': True,
-                        'is_completed': False,
-                        'is_expired': False,
-                        'days_remaining': 7,
-                        'saved_at': '2025-08-18 21:35',
-                        'couponbook': 1,})
+        OpenApiExample(
+            "예시",
+            {
+                "id": 1,
+                "coupon_url": "http://localhost:8000/couponbook/coupons/1",
+                "is_favorite": True,
+                "is_completed": False,
+                "is_expired": False,
+                "days_remaining": 7,
+                "saved_at": "2025-08-18 21:35",
+                "couponbook": 1,
+            },
+        )
     ]
 )
 class CouponListResponseSerializer(serializers.ModelSerializer):
     """
     쿠폰의 목록을 조회하는 응답에 사용되는 시리얼라이저입니다.
     """
+
     coupon_url = serializers.SerializerMethodField()
     place = serializers.SerializerMethodField()
     is_favorite = serializers.SerializerMethodField()
@@ -312,9 +413,11 @@ class CouponListResponseSerializer(serializers.ModelSerializer):
         """
         개별 쿠폰의 URL입니다.
         """
-        request = self.context['request']
-        return reverse('couponbook:coupon-detail', kwargs={'coupon_id': obj.id}, request=request)
-    
+        request = self.context["request"]
+        return reverse(
+            "couponbook:coupon-detail", kwargs={"coupon_id": obj.id}, request=request
+        )
+
     def get_place(self, obj: Coupon) -> PlaceDetailResponseSerializer:
         """
         해당 쿠폰과 연관된 가게 정보입니다.
@@ -327,12 +430,12 @@ class CouponListResponseSerializer(serializers.ModelSerializer):
         """
         해당 쿠폰을 즐겨찾기에 등록했는지의 여부입니다.
         """
-        user = self.context['request'].user
+        user = self.context["request"].user
         couponbook = CouponBook.objects.get(user=user)
         favorite_coupon = couponbook.favorite_coupons.filter(coupon=obj)
 
         return favorite_coupon.exists()
-    
+
     def get_is_completed(self, obj: Coupon) -> bool:
         """
         해당 쿠폰이 완성되었는지를 의미합니다.
@@ -343,139 +446,169 @@ class CouponListResponseSerializer(serializers.ModelSerializer):
         current_stamps: int = Stamp.objects.filter(coupon=obj).count()
 
         return max_stamps == current_stamps
-    
+
     def get_is_expired(self, obj: Coupon) -> bool:
         """
         해당 쿠폰의 유효기간이 만료되었는지를 의미합니다.
         """
-        original_template: CouponTemplate = obj.original_template
-        valid_until = original_template.valid_until
-        return valid_until < now()
-    
+        valid_until = obj.original_template.valid_until
+        return bool(valid_until and valid_until< now())
+
     def get_days_remaining(self, obj: Coupon) -> int:
         """
         해당 쿠폰의 유효기간이 며칠 남아 있는지를 의미합니다.
         """
-        original_template: CouponTemplate = obj.original_template
-        valid_until = original_template.valid_until
-        time_delta = valid_until - now()
-        return time_delta.days
+        valid_until = obj.original_template.valid_until
+        if not valid_until:
+            return None
+        return (valid_until - now()).days
 
-        
     class Meta:
         model = Coupon
-        exclude = ['original_template']
+        exclude = ["original_template"]
+
 
 @extend_schema_serializer(
     examples=[
-        OpenApiExample("예시",
-                       {'id': 1,
-                        'saved_at': '2025-08-18 21:35',
-                        'couponbook': 1,})
+        OpenApiExample(
+            "예시",
+            {
+                "id": 1,
+                "saved_at": "2025-08-18 21:35",
+                "couponbook": 1,
+            },
+        )
     ]
 )
 class CouponDetailResponseSerializer(serializers.ModelSerializer):
     """
     개별 쿠폰을 조회하는 응답에 사용되는 시리얼라이저입니다. 스탬프가 포함됩니다.
     """
+
     saved_at = serializers.DateTimeField(DATETIME_FORMAT)
     stamps = StampListResponseSerializer(many=True)
 
     class Meta:
         model = Coupon
-        exclude = ['original_template']
+        exclude = ["original_template"]
+
 
 @extend_schema_serializer(
     examples=[
-        OpenApiExample("예시",
-                       {'coupon': 1,})
+        OpenApiExample(
+            "예시",
+            {
+                "coupon": 1,
+            },
+        )
     ]
 )
 class FavoriteCouponListRequestSerializer(serializers.ModelSerializer):
     """
     쿠폰을 즐겨찾기를 등록할 때 사용되는 시리얼라이저입니다.
     """
+
     def validate(self, data) -> dict:
         """
         1. 해당 쿠폰 id에 해당하는 쿠폰이 존재하는지 확인합니다.
         2. 해당 쿠폰북에 해당 쿠폰이 즐겨찾기로 등록되어 있는지 확인합니다.
         """
-        coupon = data.get('coupon')
+        coupon = data.get("coupon")
 
         if not coupon:
-            raise serializers.ValidationError("쿠폰 id에 해당하는 쿠폰이 존재하지 않습니다.")
-        
-        couponbook = self.context['couponbook']
+            raise serializers.ValidationError(
+                "쿠폰 id에 해당하는 쿠폰이 존재하지 않습니다."
+            )
+
+        couponbook = self.context["couponbook"]
         favorite_coupon = couponbook.favorite_coupons.filter(coupon=coupon)
 
         if favorite_coupon.exists():
             raise serializers.ValidationError("이미 즐겨찾기 등록된 쿠폰입니다.")
 
         return super().validate(data)
-    
+
     def create(self, validated_data) -> FavoriteCoupon:
         """
         쿠폰 id에 해당하는 쿠폰을 현재 유저의 쿠폰북에 즐겨찾기 쿠폰으로 등록합니다.
         """
-        coupon = validated_data.pop('coupon')
-        couponbook = self.context['couponbook']
+        coupon = validated_data.pop("coupon")
+        couponbook = self.context["couponbook"]
         return FavoriteCoupon.objects.create(coupon=coupon, couponbook=couponbook)
 
     class Meta:
         model = FavoriteCoupon
-        fields = ['coupon']
+        fields = ["coupon"]
+
 
 @extend_schema_serializer(
     examples=[
-        OpenApiExample("예시",
-                       {'id': 1,
-                        'added_at': '2025-08-18 21:40',})
+        OpenApiExample(
+            "예시",
+            {
+                "id": 1,
+                "added_at": "2025-08-18 21:40",
+            },
+        )
     ]
 )
 class FavoriteCouponListResponseSerializer(serializers.ModelSerializer):
     """
     즐겨찾기 등록한 쿠폰을 조회하는 응답에 사용되는 시리얼라이저입니다.
     """
+
     coupon = CouponDetailResponseSerializer()
     added_at = serializers.DateTimeField(DATETIME_FORMAT)
 
     class Meta:
         model = FavoriteCoupon
-        exclude = ['couponbook']
+        exclude = ["couponbook"]
+
 
 @extend_schema_serializer(
     examples=[
-        OpenApiExample("예시",
-                       {'id': 1,
-                        'added_at': '2025-08-18 21:40',
-                        'coupon': 1,})
+        OpenApiExample(
+            "예시",
+            {
+                "id": 1,
+                "added_at": "2025-08-18 21:40",
+                "coupon": 1,
+            },
+        )
     ]
 )
 class FavoriteCouponDetailResponseSerializer(serializers.ModelSerializer):
     """
     FavoriteCouponDetailView의 serializer_class로 지정하기 위해 만든 시리얼라이저입니다. 실제로 조회 응답에 사용되진 않습니다.
     """
+
     added_at = serializers.DateTimeField(DATETIME_FORMAT)
+
     class Meta:
         model = FavoriteCoupon
-        exclude = ['couponbook']
+        exclude = ["couponbook"]
 
 
 # -------------------------- 쿠폰북 ----------------------------
 @extend_schema_serializer(
     examples=[
-        OpenApiExample("예시",
-                       {'id': 1,
-                        'favorite_counts': 1,
-                        'coupon_counts': 1,
-                        'stamp_counts': 1,
-                        'user': 1,})
+        OpenApiExample(
+            "예시",
+            {
+                "id": 1,
+                "favorite_counts": 1,
+                "coupon_counts": 1,
+                "stamp_counts": 1,
+                "user": 1,
+            },
+        )
     ]
 )
 class CouponBookResponseSerializer(serializers.ModelSerializer):
     """
     쿠폰북을 조회하는 응답에 사용되는 시리얼라이저입니다.
     """
+
     favorite_counts = serializers.SerializerMethodField()
     coupon_counts = serializers.SerializerMethodField()
     stamp_counts = serializers.SerializerMethodField()
@@ -486,22 +619,22 @@ class CouponBookResponseSerializer(serializers.ModelSerializer):
         """
         coupons = FavoriteCoupon.objects.filter(couponbook=obj)
         return coupons.count()
-    
+
     def get_coupon_counts(self, obj: CouponBook) -> int:
         """
         쿠폰북에 등록한 쿠폰의 개수입니다.
         """
         coupons = Coupon.objects.filter(couponbook=obj)
         return coupons.count()
-    
+
     def get_stamp_counts(self, obj: CouponBook) -> int:
         """
         지금까지 적립한 스탬프의 개수입니다.
         """
-        user = self.context['request'].user
+        user = self.context["request"].user
         stamps = Stamp.objects.filter(customer=user)
         return stamps.count()
 
     class Meta:
         model = CouponBook
-        fields = '__all__'
+        fields = "__all__"

--- a/modelproject/couponbook/serializers.py
+++ b/modelproject/couponbook/serializers.py
@@ -482,7 +482,7 @@ class CouponListResponseSerializer(serializers.ModelSerializer):
         valid_until = obj.original_template.valid_until
         return bool(valid_until and valid_until< now())
 
-    def get_days_remaining(self, obj: Coupon) -> int:
+    def get_days_remaining(self, obj: Coupon) -> int | None:
         """
         해당 쿠폰의 유효기간이 며칠 남아 있는지를 의미합니다.
         """

--- a/modelproject/couponbook/signals.py
+++ b/modelproject/couponbook/signals.py
@@ -5,8 +5,10 @@ from .models import Receipt, Stamp
 
 
 @receiver(post_save, sender=Stamp)
-def stamp_create_callback(sender: Stamp, **kwargs):
-    return
+def stamp_create_callback(sender,instance: Stamp, created: bool, **kwargs) -> None:
+    if not created:
+        return
+    
 @receiver(post_delete, sender=Stamp)
-def stamp_delete_callback(sender: Stamp, **kwargs):
+def stamp_delete_callback(sender,instance: Stamp, **kwargs):
     return

--- a/modelproject/couponbook/signals.py
+++ b/modelproject/couponbook/signals.py
@@ -7,7 +7,6 @@ from .models import Receipt, Stamp
 @receiver(post_save, sender=Stamp)
 def stamp_create_callback(sender: Stamp, **kwargs):
     return
-
 @receiver(post_delete, sender=Stamp)
 def stamp_delete_callback(sender: Stamp, **kwargs):
     return

--- a/modelproject/couponbook/signals.py
+++ b/modelproject/couponbook/signals.py
@@ -6,24 +6,8 @@ from .models import Receipt, Stamp
 
 @receiver(post_save, sender=Stamp)
 def stamp_create_callback(sender: Stamp, **kwargs):
-    """
-    스탬프가 생성되었을 때, 영수증 인스턴스에 스탬프를 연결하는 콜백 함수입니다.
-    """
-    # 생성되었을 때가 아니므로 리턴함
-    if not kwargs.get('created'):
-        return
-    
-    stamp: Stamp = kwargs.get('instance')
-    receipt: Receipt = Receipt.objects.get(receipt_number=stamp.receipt_number)
-    receipt.stamp = stamp
-    receipt.save()
+    return
 
 @receiver(post_delete, sender=Stamp)
 def stamp_delete_callback(sender: Stamp, **kwargs):
-    """
-    어떤 이유로 스탬프가 삭제될 때, 영수증 인스턴스에 연결된 스탬프를 null로 변경합니다.
-    """
-    stamp: Stamp = kwargs.get('instance')
-    receipt: Receipt = Receipt.objects.get(receipt_number=stamp.receipt_number)
-    receipt.stamp = None
-    receipt.save()
+    return

--- a/modelproject/couponbook/urls.py
+++ b/modelproject/couponbook/urls.py
@@ -4,7 +4,7 @@ from .views import (
     CouponBookDetailView, CouponListView, CouponDetailView, CouponCurationView,
     FavoriteCouponListView, FavoriteCouponDetailView,
     StampListView, StampDetailView,
-    CouponTemplateListView, CouponTemplateDetailView, CouponTemplateCreateView,
+    CouponTemplateListView, CouponTemplateDetailView,
     PlaceListView)
 
 app_name = 'couponbook'
@@ -23,7 +23,6 @@ urlpatterns = [
     # 쿠폰 템플릿 관련 엔드포인트입니다.
     path('coupon-templates/', CouponTemplateListView.as_view(), name='coupon-template-list'),
     path('coupon-templates/<int:coupon_template_id>/', CouponTemplateDetailView.as_view(), name='coupon-template-detail'),
-    path('owner/coupon-templates/create/', CouponTemplateCreateView.as_view(), name='owner-coupon-template-create'),
 
     # 가게 검색
     path('places/', PlaceListView.as_view(), name='place-list'),

--- a/modelproject/couponbook/urls.py
+++ b/modelproject/couponbook/urls.py
@@ -11,11 +11,13 @@ urlpatterns = [
     path('coupons/<int:coupon_id>/', CouponDetailView.as_view(), name='coupon-detail'),
     path('own-couponbook/curation/', CouponCurationView.as_view(), name='coupon-curation'),
     path('couponbooks/<int:couponbook_id>/favorites/', FavoriteCouponListView.as_view(), name='favorite-coupon-list'),
-    path('own-couponbook/favorites/<int:favorite_id>', FavoriteCouponDetailView.as_view(), name='favorite-coupon-detail'),
+    path('own-couponbook/favorites/<int:favorite_id>/', FavoriteCouponDetailView.as_view(), name='favorite-coupon-detail'),
     path('coupons/<int:coupon_id>/stamps/', StampListView.as_view(), name='stamp-list'),
-    path('stamps/<int:stamp_id>', StampDetailView.as_view(), name='stamp-detail'),
+    path('stamps/<int:stamp_id>/', StampDetailView.as_view(), name='stamp-detail'),
 
     # 쿠폰 템플릿 관련 엔드포인트입니다.
     path('coupon-templates/', CouponTemplateListView.as_view(), name='coupon-template-list'),
     path('coupon-templates/<int:coupon_template_id>/', CouponTemplateDetailView.as_view(), name='coupon-template-detail'),
+    path('owner/coupon-templates/create/', CouponTemplateCreateView.as_view(), name='owner-coupon-template-create'), # 여기 추가
+    path('places/', PlaceListView.as_view(), name='place-list'), # 여기 추가
 ]

--- a/modelproject/couponbook/urls.py
+++ b/modelproject/couponbook/urls.py
@@ -1,6 +1,11 @@
 from django.urls import path
 
-from .views import *
+from .views import (
+    CouponBookDetailView, CouponListView, CouponDetailView, CouponCurationView,
+    FavoriteCouponListView, FavoriteCouponDetailView,
+    StampListView, StampDetailView,
+    CouponTemplateListView, CouponTemplateDetailView, CouponTemplateCreateView,
+    PlaceListView)
 
 app_name = 'couponbook'
 
@@ -18,6 +23,8 @@ urlpatterns = [
     # 쿠폰 템플릿 관련 엔드포인트입니다.
     path('coupon-templates/', CouponTemplateListView.as_view(), name='coupon-template-list'),
     path('coupon-templates/<int:coupon_template_id>/', CouponTemplateDetailView.as_view(), name='coupon-template-detail'),
-    path('owner/coupon-templates/create/', CouponTemplateCreateView.as_view(), name='owner-coupon-template-create'), # 여기 추가
-    path('places/', PlaceListView.as_view(), name='place-list'), # 여기 추가
+    path('owner/coupon-templates/create/', CouponTemplateCreateView.as_view(), name='owner-coupon-template-create'),
+
+    # 가게 검색
+    path('places/', PlaceListView.as_view(), name='place-list'),
 ]

--- a/modelproject/modelproject/settings_base.py
+++ b/modelproject/modelproject/settings_base.py
@@ -47,10 +47,11 @@ INSTALLED_APPS = [
     "drf_spectacular",  # API 문서화
     "rest_framework_simplejwt",
     'rest_framework_simplejwt.token_blacklist',
-    "accounts",
+    "accounts.apps.AccountsConfig",
     "couponbook",
     "utils",
     "data_api",
+    "django_filters",
 ]
 
 MIDDLEWARE = [

--- a/modelproject/modelproject/settings_base.py
+++ b/modelproject/modelproject/settings_base.py
@@ -48,7 +48,7 @@ INSTALLED_APPS = [
     "rest_framework_simplejwt",
     'rest_framework_simplejwt.token_blacklist',
     "accounts.apps.AccountsConfig",
-    "couponbook",
+    'couponbook.apps.CouponbookConfig',
     "utils",
     "data_api",
     "django_filters",

--- a/modelproject/modelproject/urls.py
+++ b/modelproject/modelproject/urls.py
@@ -23,7 +23,6 @@ from drf_spectacular.views import SpectacularAPIView, SpectacularSwaggerView
 
 urlpatterns = [
     path("admin/", admin.site.urls),
-    path("api/accounts/", include("accounts.urls")),
     # OpenAPI 스키마 & UI
     path("api/schema/", SpectacularAPIView.as_view(), name="schema"),
     path("api/docs/", SpectacularSwaggerView.as_view(url_name="schema"), name="docs"),

--- a/modelproject/modelproject/urls.py
+++ b/modelproject/modelproject/urls.py
@@ -23,9 +23,7 @@ from drf_spectacular.views import SpectacularAPIView, SpectacularSwaggerView
 
 urlpatterns = [
     path("admin/", admin.site.urls),
-    # OpenAPI 스키마 & UI
-    path("api/schema/", SpectacularAPIView.as_view(), name="schema"),
-    path("api/docs/", SpectacularSwaggerView.as_view(url_name="schema"), name="docs"),
+
     # API 문서를 위한 엔드포인트들
     path("schema/", SpectacularAPIView.as_view(), name="schema"),
     path(

--- a/modelproject/pyproject.toml
+++ b/modelproject/pyproject.toml
@@ -12,6 +12,7 @@ dependencies = [
     "django-cors-headers>=4.4",
     "djangorestframework==3.16.0",
     "djangorestframework-simplejwt>=5.3",
+    "django-filter>=24.2",
     "drf-spectacular==0.28.0",
     "google-genai>=1.29.0",
     "gunicorn==23.0.0",

--- a/modelproject/uv.lock
+++ b/modelproject/uv.lock
@@ -189,6 +189,18 @@ wheels = [
 ]
 
 [[package]]
+name = "django-filter"
+version = "25.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "django" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b5/40/c702a6fe8cccac9bf426b55724ebdf57d10a132bae80a17691d0cf0b9bac/django_filter-25.1.tar.gz", hash = "sha256:1ec9eef48fa8da1c0ac9b411744b16c3f4c31176c867886e4c48da369c407153", size = 143021, upload-time = "2025-02-14T16:30:53.238Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/07/a6/70dcd68537c434ba7cb9277d403c5c829caf04f35baf5eb9458be251e382/django_filter-25.1-py3-none-any.whl", hash = "sha256:4fa48677cf5857b9b1347fed23e355ea792464e0fe07244d1fdfb8a806215b80", size = 94114, upload-time = "2025-02-14T16:30:50.435Z" },
+]
+
+[[package]]
 name = "djangorestframework"
 version = "3.16.0"
 source = { registry = "https://pypi.org/simple" }
@@ -368,6 +380,7 @@ dependencies = [
     { name = "cffi" },
     { name = "django" },
     { name = "django-cors-headers" },
+    { name = "django-filter" },
     { name = "djangorestframework" },
     { name = "djangorestframework-simplejwt" },
     { name = "drf-spectacular" },
@@ -406,6 +419,7 @@ requires-dist = [
     { name = "cryptography", marker = "extra == 'prod'", specifier = ">=45.0.6" },
     { name = "django", specifier = "==5.2.5" },
     { name = "django-cors-headers", specifier = ">=4.4" },
+    { name = "django-filter", specifier = ">=24.2" },
     { name = "djangorestframework", specifier = "==3.16.0" },
     { name = "djangorestframework-simplejwt", specifier = ">=5.3" },
     { name = "drf-spectacular", specifier = "==0.28.0" },


### PR DESCRIPTION
### ------------------------------ accounts ---------------------------------
**1. serializers.py**
손님, 점주 회원가입 시리얼라이저 분리
부가설명 : 차후 회원가입 시 손님은 자주 가는 지역을, 점주는 가게를 등록하기 위해 분리

**2. views.py**
위의 내용에 따른 회원가입 시리얼라이저 수정

### ------------------------------------- couponbook ----------------------------------
**1. models.py**
- 마이그레이션 관련 오류로 인한 CouponTemplate 클래스 수정
  -> default=None -> null=True, blank=True
- CouponTemplate.place - null=True -> null, blank=False로 수정
- RewardsInfo 클래스
   ->owner 를 OneToOneField 로 추가 # 점주와 가게를 1:1로 연결

**2. serializers.py**
a. StampListRequestSerializer 전적 수정
- 부가설명 : 기존 방식은 DB에 해당 영수증이 미리 존재해야만 스탬프 생성
   -> 입력 필드 변경 : 사용자가 영수증 번호 문자열을 보내면 스탬프 등록

**b. Place / PlaceCreate 시리얼라이저 생성**

c. CouoonTemplateList 시리얼라이저
-> reward_info 가 음수가 될 수 있어 바닥이 0으로 반환되게끔 수정

d. CouponTemplateCreate 시리얼라이저 생성
- 부가설명 : 점주가 새로운 쿠폰 템플릿을 등록할 때 사용하는 시리얼라이저
   -> place 필드가 뷰에서 현재 로그인된 점주와 연결된 가게 정보로 자동 할당

**3. signals.py 내부 코드 삭제**

**4. urls.py**
- owner/coupon-templates/create/ 추가 : 점주 쿠폰 템플릿 생성
- places/ 추가 : 가게 검색 url

**5. views.py**
- 점주 쿠폰 템플릿 등록 및 가게 검색 view 추가

### ------------------ ps. ----------------------
swagger 가독성 향상을 위한 tags 추가로 분리 설정
전반적인 기능 테스트 완료. (로컬 서버 기준)