### PR TITLE
단일 쿠폰 조회 오류 수정

### DIFF
--- a/modelproject/couponbook/urls.py
+++ b/modelproject/couponbook/urls.py
@@ -18,7 +18,7 @@ urlpatterns = [
     path('couponbooks/<int:couponbook_id>/favorites/', FavoriteCouponListView.as_view(), name='favorite-coupon-list'),
     path('own-couponbook/favorites/<int:favorite_id>/', FavoriteCouponDetailView.as_view(), name='favorite-coupon-detail'),
     path('coupons/<int:coupon_id>/stamps/', StampListView.as_view(), name='stamp-list'),
-    path('stamps/<int:pk>/', StampDetailView.as_view(), name='stamp-detail'),
+    path('stamps/<stamp_id:pk>/', StampDetailView.as_view(), name='stamp-detail'),
 
     # 쿠폰 템플릿 관련 엔드포인트입니다.
     path('coupon-templates/', CouponTemplateListView.as_view(), name='coupon-template-list'),

--- a/modelproject/couponbook/urls.py
+++ b/modelproject/couponbook/urls.py
@@ -18,7 +18,7 @@ urlpatterns = [
     path('couponbooks/<int:couponbook_id>/favorites/', FavoriteCouponListView.as_view(), name='favorite-coupon-list'),
     path('own-couponbook/favorites/<int:favorite_id>/', FavoriteCouponDetailView.as_view(), name='favorite-coupon-detail'),
     path('coupons/<int:coupon_id>/stamps/', StampListView.as_view(), name='stamp-list'),
-    path('stamps/<stamp_id:pk>/', StampDetailView.as_view(), name='stamp-detail'),
+    path('stamps/<int:stamp_id>/', StampDetailView.as_view(), name='stamp-detail'),
 
     # 쿠폰 템플릿 관련 엔드포인트입니다.
     path('coupon-templates/', CouponTemplateListView.as_view(), name='coupon-template-list'),

--- a/modelproject/couponbook/views.py
+++ b/modelproject/couponbook/views.py
@@ -1,6 +1,11 @@
 from django.shortcuts import get_object_or_404
-from drf_spectacular.utils import extend_schema, extend_schema_view, OpenApiExample, OpenApiParameter
-from rest_framework import status, generics, permissions, filters
+from django_filters.rest_framework import DjangoFilterBackend
+from drf_spectacular.utils import (OpenApiExample, OpenApiParameter,
+                                   extend_schema, extend_schema_view)
+from rest_framework import filters, generics, permissions
+from rest_framework import serializers as drf_serializers
+from rest_framework import status
+from rest_framework.exceptions import PermissionDenied, ValidationError
 from rest_framework.generics import (DestroyAPIView, ListAPIView,
                                      ListCreateAPIView, RetrieveAPIView)
 from rest_framework.permissions import IsAuthenticated
@@ -9,13 +14,9 @@ from rest_framework_simplejwt.authentication import JWTAuthentication
 
 from .curation.utils import AICurator, UserStatistics
 from .models import *
-from .serializers import *
-
 from .models import CouponTemplate, Place
+from .serializers import *
 from .serializers import CouponTemplateCreateSerializer, PlaceSerializer
-from django_filters.rest_framework import DjangoFilterBackend
-from rest_framework.exceptions import PermissionDenied, ValidationError
-from rest_framework import serializers as drf_serializers
 
 # Create your views here.
 
@@ -238,10 +239,11 @@ class FavoriteCouponDetailView(DestroyAPIView):
     lookup_url_kwarg = 'favorite_id'
 
 
+from drf_spectacular.utils import extend_schema, extend_schema_view
 # ----------------------------- 쿠폰 템플릿 (통합) -------------------------------
 from rest_framework import generics, permissions
 from rest_framework.exceptions import PermissionDenied, ValidationError
-from drf_spectacular.utils import extend_schema, extend_schema_view
+
 
 @extend_schema_view(
     get=extend_schema(
@@ -414,5 +416,4 @@ class StampDetailView(RetrieveAPIView):
     permission_classes = [IsAuthenticated]
     queryset = Stamp.objects.all()
     serializer_class = StampDetailResponseSerializer
-
-    
+    lookup_url_kwarg = 'stamp_id'


### PR DESCRIPTION
단일 쿠폰 조회 시에 오류 발생하여 urlpatterns의 `pk`를 `stamp_id`로 바꾸고 뷰에서 `lookup_url_kwarg`를 `stamp_id`로 지정. 로컬에서 단일 쿠폰 조회 및 단일 스탬프 조회 모두 작동하는 것 확인 완료