### PR TITLE
카카오맵 API를 이용해 가게에 위도와 경도 정보 추가

### DIFF
--- a/modelproject/couponbook/latlng/models.py
+++ b/modelproject/couponbook/latlng/models.py
@@ -1,0 +1,64 @@
+from decimal import Decimal
+
+import requests
+from decouple import config
+
+
+class KakaoMapPlace:
+    """
+    카카오맵 검색 결과로 나타나는 장소 정보를 클래스화하였습니다.
+    """
+    def __init__(self, place_dict: dict):
+        """
+        장소 딕셔너리를 전달받아 해당 딕셔너리의 정보를 바탕으로 인스턴스를 초기화합니다. 
+        """
+        for key in place_dict:
+           setattr(self, key, place_dict[key]) 
+    
+    def __str__(self):
+        return f"KakaoMapPlace 인스턴스 > 장소명: {self.place_name}"
+    
+    def get_latlng(self) -> tuple[Decimal, Decimal]:
+        """
+        위도(y)와 경도(x)를 튜플 형태로 반환합니다.
+        """
+        latlng = self.y, self.x
+        return tuple(map(Decimal, latlng))
+
+class KakaoMapAPIClient:
+    """
+    REST API를 사용해서 카카오맵 API와 통신하는 클라이언트입니다.
+    """
+    def __init__(self, kakao_rest_api_key=None):
+        """
+        카카오 디벨로퍼스 앱의 REST API 키가 필요합니다. (확인: 앱 > 앱 설정 > 앱 > 일반)
+
+        REST API 키를 전달하지 않으면, .env에 있는 KAKAO_REST_API_KEY 값을 찾습니다.
+        """
+        if not kakao_rest_api_key:
+            try:
+                kakao_rest_api_key = config('KAKAO_REST_API_KEY')
+            except:
+                raise Exception("REST API 키가 전달되지 않았습니다. 그러나 .env 파일에도 KAKAO_REST_API_KEY가 존재하지 않습니다.")
+        
+        self.kakao_rest_api_key = kakao_rest_api_key
+    
+    def generate_auth_header(self) -> dict:
+        """
+        카카오맵 API와 통신하기 위해 필요한 Authorization 헤더를 생성합니다. 
+        """
+        auth_value = f'KakaoAK {self.kakao_rest_api_key}'
+        header = {'Authorization': auth_value}
+        return header
+    
+    def find_place_by_keyword(self, keyword: str, **kwargs) -> KakaoMapPlace:
+        """
+        장소를 검색하여 제일 먼저 나타나는 장소 정보를 바탕으로 KakaoMapPlace 인스턴스를 만들어 돌려줍니다.
+
+        keyword는 필수 인자이며, 나머지는 https://developers.kakao.com/docs/latest/ko/local/dev-guide#search-by-keyword 문서의 쿼리 파라미터 값을 받습니다.
+        """
+        payload = {'query': keyword, **kwargs}
+        header = self.generate_auth_header()
+        r = requests.get('https://dapi.kakao.com/v2/local/search/keyword', params=payload, headers=header)
+        
+        return KakaoMapPlace(r.json()['documents'][0])

--- a/modelproject/couponbook/latlng/utils.py
+++ b/modelproject/couponbook/latlng/utils.py
@@ -1,64 +1,12 @@
 from decimal import Decimal
 
-import requests
-from decouple import config
+from .models import KakaoMapAPIClient, KakaoMapPlace
 
 
-class KakaoMapPlace:
+def get_place_latlng(place_name: str) -> tuple([Decimal, Decimal]):
     """
-    카카오맵 검색 결과로 나타나는 장소 정보를 클래스화하였습니다.
+    장소 이름에 해당하는 장소의 위도와 경도를 튜플로 반환합니다.
     """
-    def __init__(self, place_dict: dict):
-        """
-        장소 딕셔너리를 전달받아 해당 딕셔너리의 정보를 바탕으로 인스턴스를 초기화합니다. 
-        """
-        for key in place_dict:
-           setattr(self, key, place_dict[key]) 
-    
-    def __str__(self):
-        return f"KakaoMapPlace 인스턴스 > 장소명: {self.place_name}"
-    
-    def get_latlng(self) -> tuple[Decimal, Decimal]:
-        """
-        위도(y)와 경도(x)를 튜플 형태로 반환합니다.
-        """
-        latlng = self.y, self.x
-        return tuple(map(Decimal, latlng))
-
-class KakaoMapAPIClient:
-    """
-    REST API를 사용해서 카카오맵 API와 통신하는 클라이언트입니다.
-    """
-    def __init__(self, kakao_rest_api_key=None):
-        """
-        카카오 디벨로퍼스 앱의 REST API 키가 필요합니다. (확인: 앱 > 앱 설정 > 앱 > 일반)
-
-        REST API 키를 전달하지 않으면, .env에 있는 KAKAO_REST_API_KEY 값을 찾습니다.
-        """
-        if not kakao_rest_api_key:
-            try:
-                kakao_rest_api_key = config('KAKAO_REST_API_KEY')
-            except:
-                raise Exception("REST API 키가 전달되지 않았습니다. 그러나 .env 파일에도 KAKAO_REST_API_KEY가 존재하지 않습니다.")
-        
-        self.kakao_rest_api_key = kakao_rest_api_key
-    
-    def generate_auth_header(self) -> dict:
-        """
-        카카오맵 API와 통신하기 위해 필요한 Authorization 헤더를 생성합니다. 
-        """
-        auth_value = f'KakaoAK {self.kakao_rest_api_key}'
-        header = {'Authorization': auth_value}
-        return header
-    
-    def find_place_by_keyword(self, keyword: str, **kwargs) -> KakaoMapPlace:
-        """
-        장소를 검색하여 제일 먼저 나타나는 장소 정보를 바탕으로 KakaoMapPlace 인스턴스를 만들어 돌려줍니다.
-
-        keyword는 필수 인자이며, 나머지는 https://developers.kakao.com/docs/latest/ko/local/dev-guide#search-by-keyword 문서의 쿼리 파라미터 값을 받습니다.
-        """
-        payload = {'query': keyword, **kwargs}
-        header = self.generate_auth_header()
-        r = requests.get('https://dapi.kakao.com/v2/local/search/keyword', params=payload, headers=header)
-        
-        return KakaoMapPlace(r.json()['documents'][0])
+    client = KakaoMapAPIClient()
+    place: KakaoMapPlace = client.find_place_by_keyword(place_name)
+    return place.get_latlng()

--- a/modelproject/couponbook/latlng/utils.py
+++ b/modelproject/couponbook/latlng/utils.py
@@ -1,0 +1,64 @@
+from decimal import Decimal
+
+import requests
+from decouple import config
+
+
+class KakaoMapPlace:
+    """
+    카카오맵 검색 결과로 나타나는 장소 정보를 클래스화하였습니다.
+    """
+    def __init__(self, place_dict: dict):
+        """
+        장소 딕셔너리를 전달받아 해당 딕셔너리의 정보를 바탕으로 인스턴스를 초기화합니다. 
+        """
+        for key in place_dict:
+           setattr(self, key, place_dict[key]) 
+    
+    def __str__(self):
+        return f"KakaoMapPlace 인스턴스 > 장소명: {self.place_name}"
+    
+    def get_latlng(self) -> tuple[Decimal, Decimal]:
+        """
+        위도(y)와 경도(x)를 튜플 형태로 반환합니다.
+        """
+        latlng = self.y, self.x
+        return tuple(map(Decimal, latlng))
+
+class KakaoMapAPIClient:
+    """
+    REST API를 사용해서 카카오맵 API와 통신하는 클라이언트입니다.
+    """
+    def __init__(self, kakao_rest_api_key=None):
+        """
+        카카오 디벨로퍼스 앱의 REST API 키가 필요합니다. (확인: 앱 > 앱 설정 > 앱 > 일반)
+
+        REST API 키를 전달하지 않으면, .env에 있는 KAKAO_REST_API_KEY 값을 찾습니다.
+        """
+        if not kakao_rest_api_key:
+            try:
+                kakao_rest_api_key = config('KAKAO_REST_API_KEY')
+            except:
+                raise Exception("REST API 키가 전달되지 않았습니다. 그러나 .env 파일에도 KAKAO_REST_API_KEY가 존재하지 않습니다.")
+        
+        self.kakao_rest_api_key = kakao_rest_api_key
+    
+    def generate_auth_header(self) -> dict:
+        """
+        카카오맵 API와 통신하기 위해 필요한 Authorization 헤더를 생성합니다. 
+        """
+        auth_value = f'KakaoAK {self.kakao_rest_api_key}'
+        header = {'Authorization': auth_value}
+        return header
+    
+    def find_place_by_keyword(self, keyword: str, **kwargs) -> KakaoMapPlace:
+        """
+        장소를 검색하여 제일 먼저 나타나는 장소 정보를 바탕으로 KakaoMapPlace 인스턴스를 만들어 돌려줍니다.
+
+        keyword는 필수 인자이며, 나머지는 https://developers.kakao.com/docs/latest/ko/local/dev-guide#search-by-keyword 문서의 쿼리 파라미터 값을 받습니다.
+        """
+        payload = {'query': keyword, **kwargs}
+        header = self.generate_auth_header()
+        r = requests.get('https://dapi.kakao.com/v2/local/search/keyword', params=payload, headers=header)
+        
+        return KakaoMapPlace(r.json()['documents'][0])

--- a/modelproject/couponbook/models.py
+++ b/modelproject/couponbook/models.py
@@ -1,5 +1,7 @@
 from django.db import models
 
+from .latlng.utils import get_place_latlng
+
 # Create your models here.
 
 class CouponBook(models.Model):
@@ -96,6 +98,8 @@ class Place(models.Model):
     """
     name = models.CharField(max_length=20, help_text="가게 이름입니다.")
     address = models.CharField(max_length=50, help_text="가게 주소입니다. 지번 기준입니다. 예시) 서울특별시 동대문구 이문동 107")
+    lat = models.DecimalField(decimal_places=15, max_digits=18, blank=True, null=True, help_text="위도입니다. 데이터 저장 시 자동 게산됩니다.")
+    lng = models.DecimalField(decimal_places=15, max_digits=18, blank=True, null=True, help_text="경도입니다. 데이터 저장 시 자동 계산됩니다.")
     image_url = models.URLField(help_text="가게의 이미지가 담겨 있는 URL입니다.")
     opens_at = models.TimeField(help_text="영업 시작 시간입니다.")
     closes_at = models.TimeField(help_text="영업 종료 시간입니다.")
@@ -104,3 +108,12 @@ class Place(models.Model):
     tel = models.CharField(max_length=20, help_text="가게 전화번호입니다.")
     # 점주와 가게를 1:1로 연결
     owner = models.OneToOneField("accounts.User", on_delete=models.CASCADE, related_name="place", null=True, blank=True, help_text="이 매장의 점주 사용자입니다.")
+
+    def save(self, *args, **kwargs):
+        """
+        위도와 경도 정보를 카카오맵 API를 이용해서 계산해서 저장합니다.
+        """
+        lat, lng = get_place_latlng(self.name)
+        self.lat, self.lng = lat, lng
+        
+        super().save(*args, **kwargs)


### PR DESCRIPTION
가게 정보를 수정하거나 생성하면, 카카오맵 REST API를 이용해서 키워드로 장소를 검색한 후, 해당 장소의 위도와 경도 값을 바탕으로 위도(`lat`)와 경도(`lng`)가 자동 입력됨

\* 이미 생성되어 있는 가게엔 적용되지 않으므로 수정하거나 삭제 후 재생성해야 함